### PR TITLE
Entrada a api-doc para admin

### DIFF
--- a/webapp/src/components/NavMenu.jsx
+++ b/webapp/src/components/NavMenu.jsx
@@ -244,6 +244,9 @@ const NavMenu = ({ username }) => {
                     <MenuItem onClick={() => window.open(prometheusUrl)}>
                       Prometheus
                     </MenuItem>
+                    <MenuItem onClick={() => window.open(apiEndpoint + "/api-doc")}>
+                      Api
+                    </MenuItem>
                   </Menu>
                 </div>
               )}


### PR DESCRIPTION
Se le añade al menú del administrador una nueva opción para poder acceder directamente a /api-doc.
La opción se llama "Api" y abre una nueva pestana.