### PR TITLE
Se ajusta el historial a la nueva forma de las preguntas + internacionalizar al mostrar historial

### DIFF
--- a/database/package-lock.json
+++ b/database/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "database",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/statsservice/gameModels.js
+++ b/statsservice/gameModels.js
@@ -57,7 +57,7 @@ const GameHistorySchema = new Schema({
    
     questions: [
         {
-            text: { type: String, required: true },
+            question: { type: Object, required: true },
             image: { type: String },
             option1: { type: String, required: true },
             option2: { type: String, required: true },

--- a/statsservice/gameRoutes.js
+++ b/statsservice/gameRoutes.js
@@ -144,7 +144,7 @@ app.post('/newHistory', async (req, res) => {
 
     // Validar array de preguntas
     if (!Array.isArray(questions)) { // || questions.length !== 6
-      return res.status(400).json({ message: "Debes proporcionar un array de 6 preguntas." });
+      return res.status(400).json({ message: "Debes proporcionar un array." });
     }
 
     // Validaciones
@@ -179,8 +179,8 @@ app.post('/newHistory', async (req, res) => {
       date: req.body.date,
       correctAnswers: req.body.correctAnswers,
       wrongAnswers: req.body.wrongAnswers,
-      totalScore,
-      questions
+      totalScore: req.body.totalScore,
+      questions: req.body.questions
     });
   
     try {

--- a/webapp/public/resources/messages.properties
+++ b/webapp/public/resources/messages.properties
@@ -93,5 +93,14 @@ close=Cerrar
 go_back=Volver
 send=Enviar
 
+# Preguntas Historico
+history_question_button=Mostrar Preguntas
+history_question_title=Historial de Preguntas
+history_question_question=Pregunta
+history_question_image=Imagen
+history_question_options=Opciones
+history_question_correct_answer=Respuesta correcta
+history_question_image_alt=Imagen de la pregunta
+
 # Idioma actual (Formato: ES-es, EN-en)
 current_language=ES-es

--- a/webapp/public/resources/messages_en.properties
+++ b/webapp/public/resources/messages_en.properties
@@ -95,5 +95,14 @@ close=Close
 go_back=Go Back
 send=Send
 
+# Preguntas Historico
+history_question_button=Show Questions
+history_question_title=Question History
+history_question_question=Question
+history_question_image=Image
+history_question_options=Options
+history_question_correct_answer=Correct answer
+history_question_image_alt=Question image
+
 # Idioma actual (Formato: ES-es, EN-en)
 current_language=EN-en

--- a/webapp/public/resources/messages_es.properties
+++ b/webapp/public/resources/messages_es.properties
@@ -95,5 +95,14 @@ close=Cerrar
 go_back=Volver
 send=Enviar
 
+# Preguntas Historico
+history_question_button=Mostrar Preguntas
+history_question_title=Historial de Preguntas
+history_question_question=Pregunta
+history_question_image=Imagen
+history_question_options=Opciones
+history_question_correct_answer=Respuesta correcta
+history_question_image_alt=Imagen de la pregunta
+
 # Idioma actual (Formato: ES-es, EN-en)
 current_language=ES-es

--- a/webapp/src/components/PreguntasHistorico.js
+++ b/webapp/src/components/PreguntasHistorico.js
@@ -29,7 +29,7 @@ const PreguntasHistorico = ({user}) => {
                         <TableBody>
                         {user.questions.map((question,index)=>(
                             <TableRow key={index}>
-                                <TableCell>{question.text}</TableCell>
+                                <TableCell>{question.question.es}</TableCell>
                                 <TableCell>
                                     <img src={question.image} alt="Imagen de la pregunta" style={{ maxWidth: '100%', maxHeight: '100%' }} />
                                 </TableCell>

--- a/webapp/src/components/PreguntasHistorico.js
+++ b/webapp/src/components/PreguntasHistorico.js
@@ -1,37 +1,40 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Table, TableHead, TableRow, TableCell, TableBody } from "@mui/material";
+import { LanguageContext } from "../LanguageContext";
 
 
 const PreguntasHistorico = ({user}) => {
     const [show, setShow] = useState(false);
+    const { translations, currentLang } = useContext(LanguageContext);
 
     const mostrarPreguntas = () =>{
         setShow(true);
     }
 
+
     return(
         <div>
-            <Button onClick= {() => mostrarPreguntas()}>Mostrar Preguntas</Button>
+            <Button onClick= {() => mostrarPreguntas()}>{translations.history_question_button || "Mostrar Preguntas"}</Button>
             <Dialog open={show} onClose={()=> setShow(false)}>
                 <DialogTitle>
-                    Historial de Preguntas
+                    {translations.history_question_title || "Historial de Preguntas"}
                 </DialogTitle>
                 <DialogContent>
                     <Table>
                         <TableHead>
                             <TableRow>
-                                <TableCell>Pregunta</TableCell>
-                                <TableCell>Imagen</TableCell>
-                                <TableCell>Opciones</TableCell>
-                                <TableCell>Opción correcta</TableCell>
+                                <TableCell>{translations.history_question_question || "Pregunta"}</TableCell>
+                                <TableCell>{translations.history_question_image || "Imagen"}</TableCell>
+                                <TableCell>{translations.history_question_options || "Opciones"}</TableCell>
+                                <TableCell>{translations.history_question_correct_answer || "Respuesta correcta"}</TableCell>
                             </TableRow>
                         </TableHead>
                         <TableBody>
                         {user.questions.map((question,index)=>(
                             <TableRow key={index}>
-                                <TableCell>{question.question.es}</TableCell>
+                                <TableCell>{question.question[currentLang]}</TableCell>
                                 <TableCell>
-                                    <img src={question.image} alt="Imagen de la pregunta" style={{ maxWidth: '100%', maxHeight: '100%' }} />
+                                    <img src={question.image} alt={translations.history_question_image_alt || "Imagen de la pregunta"} style={{ maxWidth: '100%', maxHeight: '100%' }} />
                                 </TableCell>
                                 <TableCell>
                                 <ul>

--- a/webapp/src/components/PreguntasHistorico.test.js
+++ b/webapp/src/components/PreguntasHistorico.test.js
@@ -15,7 +15,7 @@ describe('PreguntasHistorico tests', () => {
   
   it('Se maneja el cierre del dialog', () => {
 
-    const user = { questions: [{ question: {es:'Pregunta 1'}, image: 'imagen1', option1: 'a', option2: 'b', option3: 'c', option4: 'd', correctOption: 'a'}] };
+    const user = { questions: [{ question: {es:'Pregunta 1'}, image: 'imagen1', options: ['a', 'b', 'c', 'd'], correctOption: 'a'}] };
     render(<LanguageProvider><PreguntasHistorico user={user} /></LanguageProvider>);
 
     const button = screen.getByText('Mostrar Preguntas');

--- a/webapp/src/components/PreguntasHistorico.test.js
+++ b/webapp/src/components/PreguntasHistorico.test.js
@@ -2,17 +2,20 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import PreguntasHistorico from './PreguntasHistorico';
+import { LanguageProvider } from '../LanguageContext';
 
 describe('PreguntasHistorico tests', () => {
+
+
   it('Se muestra el botón', () => {
     const user = { questions: [] };
-    render(<PreguntasHistorico user={user} />);
+    render(<LanguageProvider><PreguntasHistorico user={user} /></LanguageProvider>);
     expect(screen.getByText('Mostrar Preguntas')).toBeInTheDocument();
   });
   
   it('Se maneja el cierre del dialog', () => {
-    const user = { questions: [{ text: 'Pregunta 1', image: 'imagen1', option1: 'a', option2: 'b', option3: 'c', option4: 'd', correctOption: 'a'}] };
-    render(<PreguntasHistorico user={user} />);
+    const user = { questions: [{ question: {es:'Pregunta 1'}, image: 'imagen1', option1: 'a', option2: 'b', option3: 'c', option4: 'd', correctOption: 'a'}] };
+    render(<LanguageProvider><PreguntasHistorico user={user} /></LanguageProvider>);
     const button = screen.getByText('Mostrar Preguntas');
     fireEvent.click(button);
     expect(screen.getByText('Historial de Preguntas')).toBeInTheDocument();

--- a/webapp/src/components/game/GameQuestion.jsx
+++ b/webapp/src/components/game/GameQuestion.jsx
@@ -45,7 +45,7 @@ export default function MovieQuiz({username, nQuestions}) {
     setQuestions(prevQuestions => [
       ...prevQuestions,
       {
-        text: question.question,
+        question: question.question,
         image: question.imageUrl,
         option1: question.options[0],
         option2: question.options[1],


### PR DESCRIPTION
Se ajusta a la hora de guardar la pregunta para que se guarde tanto en español como en ingles (la nueva estructura de las preguntas) y también se ajusta al mostrarlas en el historial para que salga la pregunta en el idioma en el que estemos en el momento de consultarlo.